### PR TITLE
Fix skip scale down log issue

### DIFF
--- a/core/AutoScaleService.js
+++ b/core/AutoScaleService.js
@@ -161,11 +161,10 @@ class AutoScaleService {
 
         // don't scale down if we just scaled up
         if (direction === 'down') {
-          const lastIncrease = moment(
-            getAttribute(table, 'ProvisionedThroughput', point.indexName).LastIncreaseDateTime
-          );
+          const lastIncreaseDateTime = getAttribute(table, 'ProvisionedThroughput', point.indexName).LastIncreaseDateTime;
+          const lastIncrease = lastIncreaseDateTime ? moment(lastIncreaseDateTime) : null;
 
-          if (lastIncrease > moment().subtract(analyzeDuration.asSeconds))
+          if (lastIncrease && lastIncrease > moment().subtract(analyzeDuration))
             return this.logger.log(`${point.tableName}:${point.indexName} was just scaled up, skipping...`);
         }
 


### PR DESCRIPTION
This PR fix 2 issues

1. `getAttribute(table, 'ProvisionedThroughput', point.indexName).LastIncreaseDateTime` return `undefined` if the table haven't been increase before. And `moment(undefined) == moment() == now`. So `now > (now - downTimespan)` is always true.

2. Fix `subtract(analyzeDuration.asSeconds)` where it can accept just `Duration` object.