### PR TITLE
Changed promisify to aws-sdk promise and changed handler to use callback

### DIFF
--- a/handlers/scale-down.js
+++ b/handlers/scale-down.js
@@ -14,6 +14,6 @@ module.exports.index = (event, context, callback) => {
   );
 
   service.scaleDownTables()
-    .then(context.succeed)
-    .catch(context.fail);
+    .then(() => callback())
+    .catch(err => callback(err));
 };

--- a/handlers/scale-up.js
+++ b/handlers/scale-up.js
@@ -14,6 +14,6 @@ module.exports.index = (event, context, callback) => {
   );
 
   service.scaleUpTables()
-    .then(context.succeed)
-    .catch(context.fail);
+    .then(() => callback())
+    .catch(err => callback(err));
 };


### PR DESCRIPTION
This PR fix few things, and improve few other things
 
1. `this.configRepository.load()` now returning aws-sdk `.promise()`, so `.map` is not available anymore.
2. Along the way, I changed all other aws-sdk promisify function to use `.promise()` as well for consistency (Please recheck if I missed something).
3. By doing that, `getTableSchema()` need to be updated as well, since `.get()` is not valid anymore.
4. Changed handler to use `callback` instead of `context.succeed`, since `context.succeed` is used only if using earlier node runtime (0.10), while we're using node 6.